### PR TITLE
Issue #16 resolution. Add babel compiled js for easy webpack consumption

### DIFF
--- a/dist/animation.js
+++ b/dist/animation.js
@@ -1,0 +1,118 @@
+/* ================================================================
+ * autoresponsive-react by xdf(xudafeng[at]126.com)
+ *
+ * first created at : Mon Jun 02 2014 20:15:51 GMT+0800 (CST)
+ *
+ * ================================================================
+ * Copyright 2014 xdf
+ *
+ * Licensed under the MIT License
+ * You may not use this file except in compliance with the License.
+ *
+ * ================================================================ */
+
+'use strict';
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+var ExecutionEnvironment = require('react/lib/ExecutionEnvironment');
+var Common = require('autoresponsive-common');
+
+var Util = Common.Util;
+
+function transitionEnd() {
+  var transitionEndEventNames = {
+    WebkitTransition: 'webkitTransitionEnd',
+    MozTransition: 'transitionend',
+    OTransition: 'oTransitionEnd otransitionend',
+    transition: 'transitionend'
+  };
+  if (!ExecutionEnvironment.canUseDOM) {
+    return transitionEndEventNames;
+  }
+  var el = document.createElement('pin');
+
+  for (var _name in transitionEndEventNames) {
+    if (el.style[_name] !== undefined) {
+      return transitionEndEventNames[_name];
+    }
+  }
+  return false;
+}
+
+var ifHasTransitionEnd = transitionEnd();
+
+var prefixes = ['Webkit', 'Moz', 'ms', 'O', ''];
+
+var AnimationManager = (function () {
+  function AnimationManager() {
+    _classCallCheck(this, AnimationManager);
+
+    this.animationHandle = 'css' + (ifHasTransitionEnd ? 3 : 2) + 'Animation';
+  }
+
+  _createClass(AnimationManager, [{
+    key: 'generate',
+    value: function generate(options) {
+      Util.merge(this, options);
+      return this[this.animationHandle]();
+    }
+  }, {
+    key: 'css2Animation',
+    value: function css2Animation() {
+      var style = {};
+      style[this.horizontalDirection] = this.position[0] + 'px';
+      style[this.verticalDirection] = this.position[1] + 'px';
+
+      this.mixAnimation(style);
+      return style;
+    }
+  }, {
+    key: 'css3Animation',
+    value: function css3Animation() {
+      var _this = this;
+
+      var style = {};
+
+      prefixes.map(function (prefix) {
+        var x = undefined,
+            y = undefined;
+
+        if (_this.horizontalDirection === 'right') {
+          x = _this.containerWidth - _this.size.width - _this.position[0];
+        } else {
+          x = _this.position[0];
+        }
+
+        if (_this.verticalDirection === 'bottom') {
+          y = _this.containerHeight - _this.size.height - _this.position[1];
+        } else {
+          y = _this.position[1];
+        }
+
+        style[prefix + 'Transform'] = 'translate3d(' + x + 'px, ' + y + 'px, 0)';
+      });
+
+      this.mixAnimation(style);
+      return style;
+    }
+  }, {
+    key: 'mixAnimation',
+    value: function mixAnimation(style) {
+      var _this2 = this;
+
+      if (!this.closeAnimation) {
+        prefixes.map(function (prefix) {
+          style[prefix + 'TransitionDuration'] = _this2.transitionDuration + 's';
+          style[prefix + 'TransitionTimingFunction'] = _this2.transitionTimingFunction;
+        });
+      }
+    }
+  }]);
+
+  return AnimationManager;
+})();
+
+module.exports = AnimationManager;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,175 @@
+/* ================================================================
+ * autoresponsive-react by xdf(xudafeng[at]126.com)
+ *
+ * first created at : Mon Jun 02 2014 20:15:51 GMT+0800 (CST)
+ *
+ * ================================================================
+ * Copyright 2014 xdf
+ *
+ * Licensed under the MIT License
+ * You may not use this file except in compliance with the License.
+ *
+ * ================================================================ */
+
+'use strict';
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+
+var React = require('react');
+var Common = require('autoresponsive-common');
+
+var Util = Common.Util;
+var GridSort = Common.GridSort;
+
+var AnimationManager = require('./animation');
+
+var noop = function noop() {};
+
+var AutoResponsive = (function (_React$Component) {
+  _inherits(AutoResponsive, _React$Component);
+
+  function AutoResponsive(props) {
+    _classCallCheck(this, AutoResponsive);
+
+    _get(Object.getPrototypeOf(AutoResponsive.prototype), 'constructor', this).call(this, props);
+    this.state = {};
+  }
+
+  _createClass(AutoResponsive, [{
+    key: 'componentWillMount',
+    value: function componentWillMount() {
+      this.sortManager = new GridSort({
+        containerWidth: this.props.containerWidth,
+        gridWidth: this.props.gridWidth
+      });
+
+      this.animationManager = new AnimationManager();
+    }
+  }, {
+    key: 'componentWillReceiveProps',
+    value: function componentWillReceiveProps(nextProps) {
+
+      if (this.props.containerWidth !== nextProps.containerWidth) {
+        this.sortManager.changeProps({
+          containerWidth: nextProps.containerWidth
+        });
+      }
+    }
+  }, {
+    key: 'setPrivateProps',
+    value: function setPrivateProps() {
+      this.containerStyle = {
+        position: 'relative',
+        height: this.containerHeight || 0
+      };
+
+      if (typeof this.props.containerHeight === 'number') {
+        this.fixedContainerHeight = true;
+        this.containerStyle.height = this.props.containerHeight;
+      } else {
+        this.fixedContainerHeight = false;
+      }
+    }
+  }, {
+    key: 'componentWillUpdate',
+    value: function componentWillUpdate() {
+      this.sortManager.init();
+    }
+  }, {
+    key: 'renderChildren',
+    value: function renderChildren() {
+      var _this = this;
+
+      return React.Children.map(this.props.children, function (child, childIndex) {
+
+        if (! ~child.props.className.indexOf(_this.props.itemClassName)) {
+          return;
+        }
+
+        var childWidth = parseInt(child.props.style.width) + _this.props.itemMargin;
+        var childHeight = parseInt(child.props.style.height) + _this.props.itemMargin;
+
+        var calculatedPosition = _this.sortManager.getPosition(childWidth, childHeight, _this.containerStyle.height);
+
+        if (!_this.fixedContainerHeight) {
+
+          if (calculatedPosition[1] + childHeight > _this.containerStyle.height) {
+            _this.containerStyle.height = calculatedPosition[1] + childHeight;
+          }
+        }
+
+        var calculatedStyle = _this.animationManager.generate(Util.extend({}, _this.props, {
+          position: calculatedPosition,
+          size: {
+            width: childWidth,
+            height: childHeight
+          },
+          containerHeight: _this.containerStyle.height
+        }));
+
+        _this.mixItemInlineStyle(calculatedStyle);
+
+        _this.props.onItemDidLayout.call(_this, child);
+
+        if (childIndex + 1 === _this.props.children.length) {
+          _this.props.onContainerDidLayout.call(_this);
+        }
+
+        return React.cloneElement(child, {
+          style: Util.extend({}, child.props.style, calculatedStyle)
+        });
+      });
+    }
+  }, {
+    key: 'mixItemInlineStyle',
+    value: function mixItemInlineStyle(s) {
+      var style = {
+        position: 'absolute',
+        overflow: 'hidden'
+      };
+      Util.merge(s, style);
+    }
+  }, {
+    key: 'getContainerStyle',
+    value: function getContainerStyle() {
+      return this.containerStyle;
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      this.setPrivateProps();
+
+      return React.createElement(
+        'div',
+        { ref: "container", className: this.props.prefixClassName + '-container', style: this.getContainerStyle() },
+        this.renderChildren()
+      );
+    }
+  }]);
+
+  return AutoResponsive;
+})(React.Component);
+
+AutoResponsive.defaultProps = {
+  containerWidth: 1024,
+  containerHeight: null,
+  gridWidth: 10,
+  prefixClassName: 'rc-autoresponsive',
+  itemClassName: 'item',
+  itemMargin: 0,
+  horizontalDirection: 'left',
+  transitionDuration: 1,
+  transitionTimingFunction: 'linear',
+  verticalDirection: 'top',
+  closeAnimation: false,
+  onItemDidLayout: noop,
+  onContainerDidLayout: noop
+};
+
+module.exports = AutoResponsive;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "ui",
     "component"
   ],
-  "main": "index.js",
+  "main": "dist/index.js",
   "homepage": "http://xudafeng.github.io/autoresponsive-react",
   "author": "xudafeng@126.com",
   "repository": {
@@ -20,7 +20,8 @@
   },
   "scripts": {
     "lint": "make lint",
-    "test": "make test"
+    "test": "make test",
+    "build": "babel lib/ --out-dir dist/"
   },
   "dependencies": {
     "autoresponsive-common": "~1.0.0"


### PR DESCRIPTION
Simply adding a new script in package.json and pointing to the compiled version of the lib folder.  This resolves webpack errors when trying to import this library.