### PR TITLE
replace react ExecutionEnvironment lib with exenv module to support React 0.14

### DIFF
--- a/lib/animation.js
+++ b/lib/animation.js
@@ -12,7 +12,7 @@
  * ================================================================ */
 
 let Common = require('autoresponsive-common');
-const ExecutionEnvironment = require('react/lib/ExecutionEnvironment');
+const ExecutionEnvironment = require('exenv');
 
 let {
   Util

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "build": "make build"
   },
   "dependencies": {
-    "autoresponsive-common": "~1.0.0"
+    "autoresponsive-common": "~1.0.0",
+    "exenv": "^1.2.0"
   },
   "precommit": [
     "lint"


### PR DESCRIPTION
ExecutionEnvironment will no longer be included as of React 0.14 , switching to external exenv module which is just ExecutionEnvironment ripped from React lib to allow support.