### PR TITLE
check to make sure there is a classname before attempting to use it

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,9 @@ class AutoResponsive extends React.Component {
   renderChildren() {
     return React.Children.map(this.props.children, (child, childIndex) => {
 
-      if (!~child.props.className.indexOf(this.props.itemClassName)) {
+      if (child.props.className 
+          && this.props.itemClassName 
+          && !~child.props.className.indexOf(this.props.itemClassName)) {
         return;
       }
 


### PR DESCRIPTION
currently if the use does not give a className to the child elements of autoresponsive it will throw an error, this prevents that from happening.