### PR TITLE
fix child position when clicking the button of vertical or horizontal

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -37,7 +37,11 @@ class AnimationManager {
   css2Animation() {
     var style = {};
     style[this.horizontalDirection] = `${this.position[0]}px`;
-    style[this.verticalDirection] = `${this.position[1]}px`;
+    if (this.verticalDirection === 'bottom') {
+      style[this.verticalDirection] = `${this.position[1] + this.itemMargin}px`;
+    } else {
+      style[this.verticalDirection] = `${this.position[1]}px`;
+    }
 
     this.mixAnimation(style);
     return style;
@@ -50,7 +54,7 @@ class AnimationManager {
       let x, y;
 
       if (this.horizontalDirection === 'right') {
-        x = this.containerWidth - this.size.width - this.position[0];
+        x = this.containerWidth - this.size.width - this.position[0] + this.itemMargin;
       } else {
         x = this.position[0];
       }

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ class AutoResponsive extends React.Component {
       let childWidth = parseInt(child.props.style.width, 10) + this.props.itemMargin;
       let childHeight = parseInt(child.props.style.height, 10) + this.props.itemMargin;
 
-      let calculatedPosition = this.sortManager.getPosition(childWidth, childHeight, this.containerStyle.height);
+      let calculatedPosition = this.sortManager.getPosition(childWidth, childHeight);
 
       if (!this.fixedContainerHeight && this.props.containerWidth) {
         if (calculatedPosition[1] + childHeight > this.containerStyle.height) {
@@ -75,7 +75,8 @@ class AutoResponsive extends React.Component {
           width: childWidth,
           height: childHeight
         },
-        containerHeight: this.containerStyle.height
+        containerHeight: this.containerStyle.height,
+        itemMargin: this.props.itemMargin
       });
 
       let calculatedStyle = this.animationManager.generate(options);


### PR DESCRIPTION
1. When `CSS2` use only, clicking the button of `vertical` and the direction is `bottom`, child's position of `bottom` should add a length of `itemMargin`
 2. When supporting `CSS3`，clicking the button of `horizontal` and the direction is `right`, child's `translateX`  should add a length of `itemMargin`
3. remove useless params of `getPosition` 