### PR TITLE
Handle single child layout callbacks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,13 +42,22 @@ class AutoResponsive extends React.Component {
   }
 
   renderChildren() {
-    return React.Children.map(this.props.children, (child, childIndex) => {
-      if (child.props.className
-        && this.props.itemClassName
-        && child.props.className.indexOf(this.props.itemClassName) === -1) {
-        return;
-      }
+    const renderableChildren = React.Children.toArray(this.props.children)
+      .filter(child => {
+        if (!React.isValidElement(child)) {
+          return false;
+        }
 
+        if (child.props.className
+          && this.props.itemClassName
+          && child.props.className.indexOf(this.props.itemClassName) === -1) {
+          return false;
+        }
+
+        return true;
+      });
+
+    return renderableChildren.map((child, childIndex) => {
       const childWidth = parseInt(child.props.style.width, 10) + this.props.itemMargin;
       const childHeight = parseInt(child.props.style.height, 10) + this.props.itemMargin;
 
@@ -76,7 +85,7 @@ class AutoResponsive extends React.Component {
 
       this.props.onItemDidLayout.call(this, child);
 
-      if (childIndex + 1 === this.props.children.length) {
+      if (childIndex + 1 === renderableChildren.length) {
         this.props.onContainerDidLayout.call(this);
       }
 

--- a/test/unit/autoresponsive.test.js
+++ b/test/unit/autoresponsive.test.js
@@ -157,4 +157,36 @@ describe('AutoResponsive', () => {
       expect(child.props.style.float).to.equal(undefined);
     });
   });
+
+  it('calls layout callbacks when a single, non-array child is provided', () => {
+    const onItemDidLayout = sinon.spy();
+    const onContainerDidLayout = sinon.spy();
+
+    const instance = new AutoResponsive(Object.assign({}, AutoResponsive.defaultProps, {
+      containerWidth: 150,
+      itemMargin: 0,
+      children: createChild('solo'),
+      onItemDidLayout,
+      onContainerDidLayout,
+    }));
+
+    instance.sortManager = {
+      changeProps: sinon.spy(),
+      init: sinon.spy(),
+      getPosition: sinon.stub().returns([0, 0]),
+    };
+
+    instance.animationManager = {
+      generate: sinon.stub().returns({ top: 0, left: 0 }),
+    };
+
+    const tree = instance.render();
+    const renderer = TestRenderer.create(tree);
+    const container = renderer.root.findByProps({ className: `${instance.props.prefixClassName}-container` });
+    const renderedChild = container.findByType('div');
+
+    expect(onItemDidLayout.calledOnce).to.equal(true);
+    expect(onContainerDidLayout.calledOnce).to.equal(true);
+    expect(renderedChild.props.style.position).to.equal('absolute');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure AutoResponsive filters only renderable children and counts them correctly
- invoke layout callbacks when a single non-array child is supplied
- add unit coverage for single child rendering

## Testing
- Not run (environment lacks Node.js/npm)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933d4cb1db883219b26d0b2686f2a19)